### PR TITLE
Update popin.js

### DIFF
--- a/lib/popin.js
+++ b/lib/popin.js
@@ -112,7 +112,7 @@ var Popin = (function () {
         popin.addEventListener('click', function (event) {
           event.preventDefault();
           event.stopPropagation();
-          var el = event.target;
+          var el = this;
           _this3.open(event, el, _this3.instanciedPopinsOptions[el.getAttribute('data-popin-id')]);
         }, false);
       });


### PR DESCRIPTION
<a class=" js-popin" href="" data-target="popin-login" > <i class="menuRight-icon icon-005-user"></i><span>Mon compte</span></a>

Avec ce genre de structure de lien, le plugin remonte un problème car "event.target;" ne fait plus référence au lien mais bien à l’élément sur lequel on a cliqué.
